### PR TITLE
Update cross-compiling environment and release workflow

### DIFF
--- a/.github/workflows/cross-compiling-env.sh
+++ b/.github/workflows/cross-compiling-env.sh
@@ -64,16 +64,14 @@ case "${TARGET}" in
         echo "PYO3_CROSS_LIB_DIR=$PYTHON_LIB_DIR" >> $GITHUB_ENV
         ;;
     "aarch64-apple-darwin")
-        # macOS specific setup (if necessary)
-        # Dynamically set the Python library directory
-        # Assuming the lib directory is at the same level as bin
+        sudo apt-get update
+        sudo apt-get install libxcb-composite0-dev -y
         PYTHON_LIB_DIR="$(dirname ${PYTHON_PATH})/lib"
         echo "PYO3_CROSS_LIB_DIR=$PYTHON_LIB_DIR" >> $GITHUB_ENV
         ;;
     "x86_64-apple-darwin")
-        # macOS specific setup (if necessary)
-        # Dynamically set the Python library directory
-        # Assuming the lib directory is at the same level as bin
+        sudo apt-get update
+        sudo apt-get install libxcb-composite0-dev -y
         PYTHON_LIB_DIR="$(dirname ${PYTHON_PATH})/lib"
         echo "PYO3_CROSS_LIB_DIR=$PYTHON_LIB_DIR" >> $GITHUB_ENV
         ;;

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,6 @@ jobs:
         target:
           - aarch64-apple-darwin
           - x86_64-apple-darwin
-          - x86_64-unknown-linux-gnu
         include:
           - target: aarch64-apple-darwin
             os: macos-latest
@@ -100,10 +99,10 @@ jobs:
         run: |
           ls -l ${{ env.archive }}
 
-        # REF: https://github.com/marketplace/actions/gh-release
+      # REF: https://github.com/marketplace/actions/gh-release
       - name: Publish Archive
         uses: softprops/action-gh-release@v0.1.15
-        if: startsWith(github.ref, 'refs/tags/')
+        if: ${{ startsWith(github.ref, 'refs/tags/') }}
         with:
           draft: true
           files: ${{ env.archive }}


### PR DESCRIPTION
This commit updates the cross-compiling environment and release workflow. It adds installation of libxcb-composite0-dev package for aarch64-apple-darwin and x86_64-apple-darwin targets. It also removes x86_64-unknown-linux-gnu target from the release workflow.
- Fix #66 